### PR TITLE
Fix php7 in startup script

### DIFF
--- a/mail/rootfs/etc/cont-init.d/10-create-config.sh
+++ b/mail/rootfs/etc/cont-init.d/10-create-config.sh
@@ -72,12 +72,12 @@ if ! bashio::var.has_value "${database}"; then
         -u "${username}" -p"${password}" \
         -h "${host}" -P "${port}" \
             < /etc/postfix/createdb.sql
-php /var/www/postfixadmin/public/upgrade.php
+php7 /var/www/postfixadmin/public/upgrade.php
 /var/www/postfixadmin/scripts/postfixadmin-cli admin add ${postfixadmin}@${domain} --superadmin 1 --active 1 --password ${postfixpassword} --password2 ${postfixpassword}
 /var/www/postfixadmin/scripts/postfixadmin-cli domain add ${domain}
 fi
 
-php /var/www/postfixadmin/public/upgrade.php
+php7 /var/www/postfixadmin/public/upgrade.php
 
 newaliases
 


### PR DESCRIPTION
# Proposed Changes

php7 has to be used

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
