### PR TITLE
Allow plus address forwarding

### DIFF
--- a/mail/rootfs/etc/postfix/main.cf
+++ b/mail/rootfs/etc/postfix/main.cf
@@ -45,3 +45,6 @@ smtpd_sasl_security_options = noanonymous
 broken_sasl_auth_clients = yes
 smtpd_sasl_auth_enable = yes
 smtpd_recipient_restrictions = permit_sasl_authenticated,permit_mynetworks,reject_unauth_destination
+
+recipient_delimiter = +
+propagate_unmatched_extensions =


### PR DESCRIPTION
# Proposed Changes

this allows ruben+test@domain.com to be saved in the mailbox of ruben@domain.com. This is the same as Google, and lots of other email providers.
This causes issues when people have made a separate mailbox for ruben+test@domain.com, because this will now go to ruben@domain.com.

https://fvdm.com/code/plus-address-forwarding-in-postfix#toc-configuration-tldr

## Related Issues

None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
