### PR TITLE
Allow messages with a max of 25.6MB, instead of the default 10.

### DIFF
--- a/mail/rootfs/etc/postfix/main.cf
+++ b/mail/rootfs/etc/postfix/main.cf
@@ -48,3 +48,5 @@ smtpd_recipient_restrictions = permit_sasl_authenticated,permit_mynetworks,rejec
 
 recipient_delimiter = +
 propagate_unmatched_extensions =
+
+message_size_limit = 25600000


### PR DESCRIPTION
# Proposed Changes

* Updated the max message size to 25.6 mb.

I choose 25.6 because I see that number a lot on the internet.
The default 10 MB is not enough for me, because lots of services (gmail for example) allows up to 25mb.

## Related Issues

None