### PR TITLE
Fix global sieve script

### DIFF
--- a/mail/rootfs/etc/dovecot/conf.d/20-lmtp.conf
+++ b/mail/rootfs/etc/dovecot/conf.d/20-lmtp.conf
@@ -1,4 +1,8 @@
 protocol lmtp {
+  mail_plugins {
+    sieve = yes
+  }
+
   # Space separated list of plugins to load (default is global mail_plugins).
   postmaster_address = postmaster
 }

--- a/mail/rootfs/etc/dovecot/conf.d/90-sieve.conf
+++ b/mail/rootfs/etc/dovecot/conf.d/90-sieve.conf
@@ -6,13 +6,12 @@ sieve_plugins {
 sieve_global_extensions = vnd.dovecot.pipe
 sieve_pipe_bin_dir = /usr/bin
 
-sieve_script default {
-  type = default
-  name = default
+sieve_script before {
+  type = before
+  name = movespam
   driver = file
   path = /var/mail/vmail/sieve/global/spam-global.sieve
 }
-
 
 imapsieve_from Spam {
   sieve_script ham {
@@ -21,6 +20,7 @@ imapsieve_from Spam {
     path = /var/mail/vmail/sieve/global/report-ham.sieve
   }
 }
+
 mailbox Spam {
   sieve_script spam {
     type = before


### PR DESCRIPTION
# Proposed Changes

The Sieve mail plugin was missing in the configuration.
The global script did not move mail tagged as SPAM to the users spam folder.
