### PR TITLE
Configure settings for ManageSieve

### DIFF
--- a/mail/config.yaml
+++ b/mail/config.yaml
@@ -29,6 +29,7 @@ ports_description:
   465/tcp: SMTP
   587/tcp: SMTP
   993/tcp: IMAPS
+  4190/tcp: ManageSieve
 hassio_api: true
 options:
   my_hostname: mydomain.no-ip.com

--- a/mail/rootfs/etc/dovecot/conf.d/20-managesieve.conf
+++ b/mail/rootfs/etc/dovecot/conf.d/20-managesieve.conf
@@ -11,3 +11,8 @@ service managesieve {
 
 protocol sieve {
 }
+
+sieve_script personal {
+  path = ~/sieve
+  active_path = ~/.dovecot.sieve
+}


### PR DESCRIPTION
# Proposed Changes

> Expose ManageSieve port and set personal script storage for users. Users will be able to use 3rd party software to upload personal Sieve scripts


