### PR TITLE
Enable imap on port 143

### DIFF
--- a/mail/rootfs/etc/dovecot/conf.d/10-master.conf
+++ b/mail/rootfs/etc/dovecot/conf.d/10-master.conf
@@ -1,6 +1,6 @@
 service imap-login {
   inet_listener imap {
-    port = 0
+    #port = 0
   }
   inet_listener imaps {
     #port = 993


### PR DESCRIPTION
# Proposed Changes

> Enable port 143 (imap) in Dovecot. The port will not be exposed by the add-on to the HA Host network. This is a preparation for the release of my Roundcube add-on.
