### PR TITLE
Prevent ignoring errors caused by `;`

### DIFF
--- a/mail/Dockerfile
+++ b/mail/Dockerfile
@@ -39,9 +39,9 @@ RUN apk add --no-cache \
         | tar -C / -Jxpf - \
     && mkdir /var/www/postfixadmin \
     && curl -L -s "https://github.com/postfixadmin/postfixadmin/archive/postfixadmin-${POSTFIXADMIN_VERSION}.tar.gz" \
-        | tar zxvf - -C /var/www/postfixadmin --strip-components=1; \
-        mkdir -p /var/www/postfixadmin/templates_c; \
-        chown -R nginx: /var/www/postfixadmin; \
+        | tar zxvf - -C /var/www/postfixadmin --strip-components=1 && \
+        mkdir -p /var/www/postfixadmin/templates_c && \
+        chown -R nginx: /var/www/postfixadmin && \
         mkdir -p /etc/postfix/sql \
     && rm -f -r \
         /tmp/* \

--- a/mail/rootfs/etc/cont-init.d/10-create-config.sh
+++ b/mail/rootfs/etc/cont-init.d/10-create-config.sh
@@ -50,8 +50,8 @@ rm -fr /var/mail
 ln -s /data/mail /var/mail
 mkdir -p /var/mail/vmail/sieve/global
 chown -R vmailuser:vmail /var/mail
-mkdir -p /var/www/postfixadmin/templates_c; \
-chown -R nginx: /var/www/postfixadmin; \
+mkdir -p /var/www/postfixadmin/templates_c
+chown -R nginx: /var/www/postfixadmin
 
 # Modify config files for S6-logging
 sed -i 's#^ + .*$# + -^auth\\. -^authpriv\\. -mail\\. $T ${dir}/everything#' /etc/s6-overlay/s6-rc.d/syslogd-log/run


### PR DESCRIPTION
# Proposed Changes

Prevent issues like #388 from happening again.

This happened because errors from commands before a `;` are ignored.

I have replaced all relevant `;` in shell scripts with `&&`, or removed them where it made sense.

## Related Issues

> #388
