### PR TITLE
Allow to change the number of IMAP connections per client

### DIFF
--- a/mail/DOCS.md
+++ b/mail/DOCS.md
@@ -163,6 +163,12 @@ addresses to relay email through this server. This option should only be
 used for internal networks or hosts. Before using it, be sure to read the Postfix
 documentation to understand the security implications of setting this option.
 
+#### Option: `mail_max_userip_connections` (optional)
+
+Use this optional setting if you want to change the maximum number of IMAP
+connections allowed for a user from each IP address. The standard setting
+is to allow 10 connections.
+
 ```yaml
 192.168.1.0/24 192.168.3.12
 ```

--- a/mail/config.yaml
+++ b/mail/config.yaml
@@ -53,4 +53,5 @@ schema:
   smtp_relayhost_credentials: str?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   message_size_limit: int
+  mail_max_userip_connections: int?
   mynetworks: str?

--- a/mail/rootfs/etc/cont-init.d/10-create-config.sh
+++ b/mail/rootfs/etc/cont-init.d/10-create-config.sh
@@ -22,6 +22,7 @@ myhostname=$(bashio::config 'my_hostname')
 domain=$(bashio::config 'domain_name')
 relaycredentials=$(bashio::config 'smtp_relayhost_credentials')
 messagesizelimit=$(bc <<< "$(bashio::config 'message_size_limit' '10') * 1024000")
+maxuserip=$(bashio::config 'mail_max_userip_connections')
 mynetworks=$(bashio::config 'mynetworks')
 
 adduser -S -D -H syslog
@@ -78,6 +79,10 @@ sed -i 's/exec php/exec php84/g' /var/www/postfixadmin/scripts/postfixadmin-cli
 
 if bashio::config.has_value "smtp_relayhost"; then
 sed -i "s/relayhost =/relayhost = ${relayhost}/g" /etc/postfix/main.cf
+fi
+
+if bashio::config.has_value "mail_max_userip_connections"; then
+sed -i "s/mail_max_userip_connections =/mail_max_userip_connections = ${maxuserip}/g" /etc/dovecot/conf.d/20-imap.conf
 fi
 
 if bashio::config.has_value "smtp_relayhost_credentials"; then

--- a/mail/rootfs/etc/dovecot/conf.d/20-imap.conf
+++ b/mail/rootfs/etc/dovecot/conf.d/20-imap.conf
@@ -4,4 +4,5 @@ protocol imap {
     imap_sieve = yes
     imap_quota = yes
   }
+  mail_max_userip_connections = 10
 }


### PR DESCRIPTION
# Proposed Changes

> This will make mail_max_userip_connections configurable. If not set, we use 10 as this is the Dovecot default value

## Related Issues

> (https://github.com/erik73/hassio-addons/issues/294)

