### PR TITLE
Fix Dovecot trying to connect via SSL to MariaDB

### DIFF
--- a/mail/rootfs/etc/dovecot/conf.d/auth-sql.conf.ext
+++ b/mail/rootfs/etc/dovecot/conf.d/auth-sql.conf.ext
@@ -8,6 +8,7 @@ mysql mariadb {
   mysql_user = postfixadmin
   mysql_password = postfixadmin
   mysql_dbname = postfixadmin
+  mysql_ssl = no
 }
 
 passdb sql {


### PR DESCRIPTION
# Proposed Changes

> Fix Dovecot trying to connect via SSL to MariaDB

## Related Issues

> Fix for: https://github.com/erik73/addon-mail/issues/430


